### PR TITLE
Configure/jekyll

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,24 @@
+language: ruby
+rvm:
+- 2.1
+
+cache: bundler
+
+branches:
+  only:
+  - gh-pages     # test the gh-pages branch
+
+env:
+  global:
+    - NOKOGIRI_USE_SYSTEM_LIBRARIES=true
+
+install:
+  - gem install bundler
+
+before_script:
+  - npm install -g bower
+  - bower install -f
+
+script:
+  - bundle install --jobs=3 --retry=3
+  - bundle exec jekyll build

--- a/_config.yml
+++ b/_config.yml
@@ -9,3 +9,10 @@ github_username:  bradwestfall
 
 # Build settings
 markdown: kramdown
+
+exclude:
+  - bower_components/*.html
+
+# Jekyll plugins to load
+gems:
+  - jekyll-sitemap

--- a/api/1.0/all/index.html
+++ b/api/1.0/all/index.html
@@ -1,4 +1,5 @@
 ---
+sitemap: false
 ---
 	{% capture companies %}
 	[
@@ -42,9 +43,6 @@
 	"locations": {{ site.data.locations | jsonify }},
 
 	"languages" : {{ site.data.languages | jsonify }},
-	
+
 	"companies": {{ companies | remove_first: ','}}
 }
-
-
-

--- a/api/1.0/categories/index.html
+++ b/api/1.0/categories/index.html
@@ -1,4 +1,5 @@
 ---
+sitemap: false # do not change unless||until individual profile pages exist.
 ---
 {
 	"languages" : {{ site.data.languages | jsonify }},

--- a/api/1.0/categories/languages/index.html
+++ b/api/1.0/categories/languages/index.html
@@ -1,3 +1,4 @@
 ---
+sitemap: false
 ---
 {{ site.data.languages | jsonify }}

--- a/api/1.0/categories/locations/index.html
+++ b/api/1.0/categories/locations/index.html
@@ -1,3 +1,4 @@
 ---
+sitemap: false # do not change unless||until individual profile pages exist.
 ---
 {{ site.data.locations | jsonify }}

--- a/api/1.0/companies/index.html
+++ b/api/1.0/companies/index.html
@@ -1,4 +1,5 @@
 ---
+sitemap: false
 ---
 
 {% capture companies %}

--- a/developer_profiles/andrew-ewing.md
+++ b/developer_profiles/andrew-ewing.md
@@ -1,12 +1,13 @@
 ---
 layout: dev_profile
-developer_name: Andrew Ewing 
+developer_name: Andrew Ewing
 link: http://phenocode.com
 co-founder-willing: true
 linkedin: https://www.linkedin.com/in/azphpdeveloper
 email: drew[at]phenocode.com
 website: http://phenocode.com
-twitter: gurudrew 
-github: aewing 
+twitter: gurudrew
+github: aewing
 stack: [Hack, Flow, PHP, JavaScript, CSS, Less, Node, Linux/Unix, Nginx, Laravel, DevOps]
+sitemap: false # do not change unless||until individual profile pages exist.
 ---

--- a/developer_profiles/brad-westfall.md
+++ b/developer_profiles/brad-westfall.md
@@ -9,4 +9,5 @@ website: http://azpixels.com
 twitter: bradwestfall
 github: bradwestfall
 stack: [CSS, JavaScript, PHP]
+sitemap: false # do not change unless||until individual profile pages exist.
 ---

--- a/developer_profiles/bryon-keck.md
+++ b/developer_profiles/bryon-keck.md
@@ -9,4 +9,5 @@ website: http://bryonkeck.com
 twitter: vertex
 github: vertex
 stack: [CSS, JavaScript, PHP, Node]
+sitemap: false # do not change unless||until individual profile pages exist.
 ---

--- a/developer_profiles/chris-irish.md
+++ b/developer_profiles/chris-irish.md
@@ -9,4 +9,5 @@ website: http://velocitylabs.io
 twitter: SupaIrish
 github: supairish
 stack: [Ruby, Rails, Ember, JavaScript, jQuery, MySQL, Postgres, DevOps, AWS]
+sitemap: false # do not change unless||until individual profile pages exist.
 ---

--- a/developer_profiles/chris-vogt.md
+++ b/developer_profiles/chris-vogt.md
@@ -8,4 +8,5 @@ website: http://www.chrisvogt.me
 twitter: c1v0
 github: chrisvogt
 stack: [Linux/Unix, DevOps, PHP, JavaScript, ]
+sitemap: false # do not change unless||until individual profile pages exist.
 ---

--- a/developer_profiles/curtis-miller.md
+++ b/developer_profiles/curtis-miller.md
@@ -9,4 +9,5 @@ website: http://velocitylabs.io
 twitter: curtism
 github: curtis
 stack: [Ruby, Ruby on Rails, JavaScript]
+sitemap: false # do not change unless||until individual profile pages exist.
 ---

--- a/developer_profiles/dave-tapley.md
+++ b/developer_profiles/dave-tapley.md
@@ -8,4 +8,5 @@ website: http://velocitylabs.io
 twitter: davetapley
 github: dukedave
 stack: [Ruby, Rails, JavaScript, Haskell]
+sitemap: false # do not change unless||until individual profile pages exist.
 ---

--- a/developer_profiles/evan-agee.md
+++ b/developer_profiles/evan-agee.md
@@ -9,4 +9,5 @@ website: http://evanagee.com
 twitter: EvanAgee
 github: EvanAgee
 stack: [HTML5, CSS/SCSS/SASS, JavaScript/jQuery, PHP, MySQL, CoffeeScript, WordPress Theming and Development, Drupal Theming and Development]
+sitemap: false # do not change unless||until individual profile pages exist.
 ---

--- a/developer_profiles/nate-jackman.md
+++ b/developer_profiles/nate-jackman.md
@@ -7,4 +7,5 @@ linkedin: https://www.linkedin.com/pub/nate-jackman/15/14a/a98
 email: natejackman@gmail.com
 github: NateJackman
 stack: [JavaScript, Angular.js, React.js, Node.js, CSS, HTML]
+sitemap: false # do not change unless||until individual profile pages exist.
 ---

--- a/developer_profiles/sid-tantia.md
+++ b/developer_profiles/sid-tantia.md
@@ -6,4 +6,5 @@ linkedin: https://www.linkedin.com/pub/sid-tantia/99/528/357
 email: sid[at]mailhaven.com
 github: sstgithub
 stack: [JavaScript/jQuery, CoffeeScript, Ember JS, Ruby, Ruby on Rails]
+sitemap: false # do not change unless||until individual profile pages exist.
 ---

--- a/developer_profiles/stephen-curtin.md
+++ b/developer_profiles/stephen-curtin.md
@@ -9,4 +9,5 @@ website: http://www.scurtin.com
 twitter: curtins
 github: curtins
 stack: [CSS, JavaScript, LAMP, MongoDB, PHP, MySQL, Drupal, .NET]
+sitemap: false # do not change unless||until individual profile pages exist.
 ---


### PR DESCRIPTION
- [x] Adds Travis. (Complete setup at [travisci.org](http://travisci.org).)
- [x] Excludes all html pages under `bower_components/` from Jekyll.
- [x] Adds a sitemap using [jekyll/jekyll-sitemap](https://github.com/jekyll/jekyll-sitemap).
  - [x] Disables the [temp file](https://github.com/bradwestfall/webdevphoenix/blob/gh-pages/_layouts/dev_profile.html) template from being included in the sitemap by turning off the sitemap for each individual developer profile.
