### PR TITLE
Finishes adding the open graph and Twitter meta data.

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -6,7 +6,15 @@
     <title>{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}</title>
     <meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
     <meta name="author" content="Brad Westfall">
+
+    <meta name="og:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
+    <meta name="og:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
+    <meta name="og:url" content="{{ site.url }}">
     <meta name="og:image" content="{{ site.url }}/images/og-banner.png">
+    <meta name="og:author" content="Brad Westfall">
+
+    <meta name="twitter:title" content="{% if page.title %}{{ page.title }}{% else %}{{ site.title }}{% endif %}">
+    <meta name="twitter:description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.description }}{% endif %}">
     <meta name="twitter:card" content="summary_large_image">
     <meta name="twitter:site" content="@bradwestfall">
     <meta name="twitter:creator" content="@bradwestfall">


### PR DESCRIPTION
Validated and filled in the rest of the [open graph](https://developers.facebook.com/tools/debug/) and [Twitter](https://cards-dev.twitter.com/validator) metadata so the site previews look fancy when shared on either network.

![validate-facebook-og](https://cloud.githubusercontent.com/assets/1934719/8323676/9349125a-19fc-11e5-883f-90bef510c5e2.JPG)

![validate-twitter-meta](https://cloud.githubusercontent.com/assets/1934719/8323675/90dfe840-19fc-11e5-8e45-b9b5ec5589de.JPG)
